### PR TITLE
Update to run on CUDA9 and 10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,27 @@
 # If the CUDA environment variables are already set, use them
-CUDA_PATH?=${CUDA_HOME}
-
-# If the above did not find anything, then use the default path to
-# NVIDIA CUDA (typically installed into /usr/local/cuda)
-CUDA_PATH?=/usr/local/cuda
-
-# If none of the above worked, try some other common paths
-ifneq ("$(wildcard $(CUDA_PATH))","")
-# The default PATH is good - nothing else to do
-else ifneq ("$(wildcard /usr/local/cuda-9.0)","")
-CUDA_PATH=/usr/local/cuda-9.0
-else ifneq ("$(wildcard /usr/local/cuda-8.0)","")
-CUDA_PATH=/usr/local/cuda-8.0
-else ifneq ("$(wildcard /usr/local/cuda-7.5)","")
-CUDA_PATH=/usr/local/cuda-7.5
-else ifneq ("$(wildcard /usr/local/cuda-7.0)","")
-CUDA_PATH=/usr/local/cuda-7.0
-else ifneq ("$(wildcard /usr/local/cuda-6.5)","")
-CUDA_PATH=/usr/local/cuda-6.5
-else ifneq ("$(wildcard /opt/cuda)","")
-CUDA_PATH=/opt/cuda
+ifeq ($(CUDA_HOME), )
+	# If the above did not find anything, then use the default path to
+	# NVIDIA CUDA (typically installed into /usr/local/cuda)
+	# If none of the above worked, try some other common paths
+	ifneq ($(wildcard /usr/local/cuda), )
+		CUDA_PATH=/usr/local/cuda
+	else ifneq ($(wildcard /usr/local/cuda-9.1),)
+		CUDA_PATH=/usr/local/cuda-9.1
+	else ifneq ($(wildcard /usr/local/cuda-9.0),)
+		CUDA_PATH=/usr/local/cuda-9.0
+	else ifneq ($(wildcard /usr/local/cuda-8.0),)
+		CUDA_PATH=/usr/local/cuda-8.0
+	else ifneq ($(wildcard /usr/local/cuda-7.5),)
+		CUDA_PATH=/usr/local/cuda-7.5
+	else ifneq ($(wildcard /usr/local/cuda-7.0),)
+		CUDA_PATH=/usr/local/cuda-7.0
+	else ifneq ($(wildcard /usr/local/cuda-6.5),)
+		CUDA_PATH=/usr/local/cuda-6.5
+	else ifneq ($(wildcard /opt/cuda),)
+		CUDA_PATH=/opt/cuda
+	endif
+else
+	CUDA_PATH=$(CUDA_HOME)
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GCCPATH=/usr
 
 NVCC=${CUDA_PATH}/bin/nvcc
 CCPATH=${GCCPATH}/bin
-CUDA_VER_MAJOR=$(shell cat ${CUDA_PATH}/version.txt | sed -e 's/CUDA Version //' | cut -c 1)
+CUDA_VER_MAJOR=$(shell cat ${CUDA_PATH}/version.txt | sed -e 's/CUDA Version //' | cut -d '.' -f 1)
 
 ifeq ($(shell expr ${CUDA_VER_MAJOR} \>= 9), 1)
 	NVCCFLAGS=-gencode=arch=compute_30,code=sm_30 -gencode=arch=compute_35,code=compute_35 -gencode=arch=compute_37,code=compute_37 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_52,code=sm_52 -I. -I${CUDA_PATH}/include --fatbin

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,15 @@ GCCPATH=/usr
 
 NVCC=${CUDA_PATH}/bin/nvcc
 CCPATH=${GCCPATH}/bin
+CUDA_VER_MAJOR=$(shell cat ${CUDA_PATH}/version.txt | sed -e 's/CUDA Version //' | cut -c 1)
 
+ifeq ($(shell expr ${CUDA_VER_MAJOR} \>= 9), 1)
+	NVCCFLAGS=-gencode=arch=compute_30,code=sm_30 -gencode=arch=compute_35,code=compute_35 -gencode=arch=compute_37,code=compute_37 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_52,code=sm_52 -I. -I${CUDA_PATH}/include --fatbin
+else
+	NVCCFLAGS=-gencode=arch=compute_20,code=sm_20 -gencode=arch=compute_30,code=sm_30 -gencode=arch=compute_35,code=compute_35 -gencode=arch=compute_37,code=compute_37 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_52,code=sm_52 -I. -I${CUDA_PATH}/include --fatbin
+endif
 
 all: gpu_burn
-
-NVCCFLAGS=-gencode=arch=compute_20,code=sm_20 -gencode=arch=compute_30,code=sm_30 -gencode=arch=compute_35,code=compute_35 -gencode=arch=compute_37,code=compute_37 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_52,code=sm_52 -I. -I${CUDA_PATH}/include --fatbin
 
 gpu_burn.cuda_kernel: compare.cu Makefile
 	PATH=.:${CCPATH}:${PATH} ${NVCC} ${NVCCFLAGS} compare.cu -o $@


### PR DESCRIPTION
- Fix `CUDA_PATH` configuration when `CUDA_HOME` is not set
  - `CUDA_PATH` is not properly set when `CUDA_HOME` is not set in env.
- Use proper `NVCC_FLAGS` when `CUDA_VERSION` is `9.x.x` and above.
  - `-gencode=arch=compute_20,code=sm_20` is removed in `9.x.x` and above.
  - Related: https://github.com/kaldi-asr/kaldi/issues/1918